### PR TITLE
Scripts and configs for creating deb packages

### DIFF
--- a/debian/build.sh
+++ b/debian/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+
+echo BUILDING DEB PACKAGE...
+
+(cd $SCRIPT_DIR && fakeroot dpkg-deb -b phenix-apps)
+
+echo DONE BUILDING DEB PACKAGE

--- a/debian/phenix-apps/DEBIAN/control
+++ b/debian/phenix-apps/DEBIAN/control
@@ -1,0 +1,11 @@
+Package: phenix-apps
+Version: 0.1
+Section: utils
+Priority: extra
+Architecture: amd64
+Depends: golang-phenix-apps, python3-phenix-apps
+Maintainer: Bryan Richardson <bryan@activeshadow.com>
+Description:
+ some stuff
+ .
+ and some other stuff

--- a/src/go/build.sh
+++ b/src/go/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+
+mkdir -p $SCRIPT_DIR/bin
+
+GOBIN=$SCRIPT_DIR/bin go install ./...

--- a/src/go/debian/build.sh
+++ b/src/go/debian/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+APPS=$SCRIPT_DIR/..
+
+
+which docker &> /dev/null
+DOCKER=$?
+
+if (( $DOCKER == 0 )); then
+  echo "Docker detected, so Docker will be used to build golang-phenix-apps."
+
+  (cd $APPS && $APPS/docker-build.sh)
+else
+  echo "Docker not detected, using natively installed Go."
+
+  (cd $APPS && $APPS/build.sh)
+fi
+
+
+echo COPYING FILES...
+
+DST=$SCRIPT_DIR/golang-phenix-apps/usr
+
+mkdir -p $DST
+
+cp -r $APPS/bin $DST/
+
+echo COPIED FILES
+
+
+echo BUILDING DEB PACKAGE...
+
+(cd $SCRIPT_DIR && fakeroot dpkg-deb -b golang-phenix-apps)
+
+echo DONE BUILDING DEB PACKAGE

--- a/src/go/debian/clean.sh
+++ b/src/go/debian/clean.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+rm -r $SCRIPT_DIR/golang-phenix-apps/usr

--- a/src/go/debian/golang-phenix-apps/DEBIAN/control
+++ b/src/go/debian/golang-phenix-apps/DEBIAN/control
@@ -1,0 +1,11 @@
+Package: golang-phenix-apps
+Version: 0.1
+Section: utils
+Priority: extra
+Architecture: amd64
+Depends:
+Maintainer: Bryan Richardson <bryan@activeshadow.com>
+Description:
+ some stuff
+ .
+ and some other stuff

--- a/src/go/docker-build.sh
+++ b/src/go/docker-build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+
+which docker &> /dev/null
+
+if (( $? )); then
+  echo "Docker must be installed (and in your PATH) to use this build script. Exiting."
+  exit 1
+fi
+
+
+USER_UID=$(id -u)
+USERNAME=builder
+
+
+docker build -t golang-phenix-apps:builder -f - . <<EOF
+FROM golang:1.14
+
+RUN groupadd --gid $USER_UID $USERNAME \
+  && useradd -s /bin/bash --uid $USER_UID --gid $USER_UID -m $USERNAME
+EOF
+
+
+echo BUILDING golang-phenix-apps...
+
+docker run -it --rm -v $(pwd):/phenix-apps -w /phenix-apps -u $USERNAME \
+  golang-phenix-apps:builder ./build.sh
+
+echo DONE BUILDING golang-phenix-apps

--- a/src/python/docker-build.sh
+++ b/src/python/docker-build.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -e
+
+
+which docker &> /dev/null
+
+if (( $? )); then
+  echo "Docker must be installed (and in your PATH) to use this build script. Exiting."
+  exit 1
+fi
+
+
+USER_UID=$(id -u)
+USERNAME=builder
+
+
+docker build -t python-phenix-apps:builder -f - . <<EOF
+FROM ubuntu:focal
+
+RUN groupadd --gid $USER_UID $USERNAME \
+  && useradd -s /bin/bash --uid $USER_UID --gid $USER_UID -m $USERNAME
+
+ENV TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt update && apt install -y \
+  apt-file \
+  build-essential \
+  debhelper \
+  devscripts \
+  dpkg-dev \
+  fakeroot \
+  python3 \
+  python3-apt \
+  python3-distro \
+  python3-pip
+
+RUN python3 -m pip install wheel2deb
+EOF
+
+
+echo PACKAGING python-phenix-apps...
+
+docker run -it --rm -v $(pwd):/phenix-apps -w /phenix-apps -u $USERNAME python-phenix-apps:builder ./package.sh
+
+echo DONE PACKAGING python-phenix-apps

--- a/src/python/package.sh
+++ b/src/python/package.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+cat > wheel2deb.yml << EOF
+.:
+  maintainer_name: Bryan Richardson
+  maintainer_email: bryan@activeshadow.com
+EOF
+
+# Build wheel for phenix-apps
+python3 -m pip wheel .
+
+# Convert all wheels to debian source packages
+wheel2deb --map attrs=attr
+
+# Call dpkg-buildpackages for each source package
+wheel2deb build
+
+rm -f *.whl
+rm wheel2deb.yml


### PR DESCRIPTION
Looking to host a `phenix-apps` deb package at https://apt.sceptre.dev alongside the existing minimega deb package (that includes phenix). This PR includes scripts to build deb packages for `golang-phenix-apps` and `python3-phenix-apps`, as well as a `phenix-apps` metapackage deb that simply requires the other two as dependencies.