### PR TITLE
Fix os.exit error in cc phenix app

### DIFF
--- a/src/python/phenix_apps/apps/scorch/cc/cc.py
+++ b/src/python/phenix_apps/apps/scorch/cc/cc.py
@@ -61,7 +61,7 @@ class CC(ComponentBase):
 
                         if results['exitcode']:
                             self.eprint(f"command '{results['cmd']}' returned a non-zero exit code of '{results['exitcode']}'")
-                            os.exit(1)
+                            sys.exit(1)
 
                         self.print(f"results from '{results['cmd']}':")
                         self.print(results['stdout'])
@@ -87,7 +87,7 @@ class CC(ComponentBase):
                                 else:
                                     self.eprint('results validation failed')
 
-                                os.exit(1)
+                                sys.exit(1)
                             else:
                                 self.print('results are valid')
                     else:


### PR DESCRIPTION
os.exit(int) is not a valid function. os._exit(int) is valid, however, is mainly used when exiting child processes which does not appear to be occurring with this code. Based on this, I switched the code to use sys.exit(1)

results validation failed: 1Traceback (most recent call last): 
File "/usr/local/bin/phenix-scorch-component-cc", line 8, 
in <module> sys.exit(main()) File 
"/usr/local/lib/python3.8/dist-packages/phenix_apps/apps/scorch/cc/cc.py",
 line 161, in main CC() File "/usr/local/lib/python3.8/dist-packages/phenix_apps/apps/scorch/cc/cc.py",
  line 11, in __init__ self.execute_stage() File "/usr/local/lib/python3.8/dist-packages/phenix_apps/apps/scorch/__init__.py",
   line 104, in execute_stage stages_dict[self.stage]() File "/usr/local/lib/python3.8/dist-packages/phenix_apps/apps/scorch/cc/cc.py",
    line 19, in start self.__run('start') File "/usr/local/lib/python3.8/dist-packages/phenix_apps/apps/scorch/cc/cc.py", line 90, 
    in __run os.exit(1)AttributeError: module 'os' has no attribute 'exit' 